### PR TITLE
Switch flake8 source repository to github.com

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
     hooks:
       - id: isort
 
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/pycqa/flake8
     rev: 4.0.1
     hooks:
       - id: flake8


### PR DESCRIPTION
The project has migrated from gitlab.com to github.com. It has been discontinued on gitlab.com and is now hidden from the public.